### PR TITLE
Clear timeout if finish is called in within time

### DIFF
--- a/lib/socks-client.js
+++ b/lib/socks-client.js
@@ -51,6 +51,12 @@ var SmartBuffer = require('smart-buffer');
 
         options.proxy.authentication = auth;
 
+        // Connect & negotiation timeout
+
+        var timeout = setTimeout(function () {
+            finish(new Error("Connection Timed Out"), socket, null, callback);
+        }, options.timeout);
+
         // Socket events
         socket.once('close', function () {
             finish(new Error("Socket Closed"), socket, null, callback);
@@ -68,12 +74,6 @@ var SmartBuffer = require('smart-buffer');
                 throw new Error("Please specify a proxy type in options.proxy.type");
             }
         });
-
-        // Connect & negotiation timeout
-
-        setTimeout(function () {
-            finish(new Error("Connection Timed Out"), socket, null, callback);
-        }, options.timeout);
 
         socket.connect(options.proxy.port, options.proxy.ipaddress);
 
@@ -261,6 +261,8 @@ var SmartBuffer = require('smart-buffer');
                     socket.destroy();
                     socket = null;
                 }
+
+                clearTimeout(timeout);
                 callback(err, socket, info);
             }
         }


### PR DESCRIPTION
Currently if I run the example (with or without proper socks configured) it waits for 10 seconds until closing, even though the error is displayed almost instantly.

```
› time node connect.js
[Error: Socket Closed]
node connect.js  0.06s user 0.02s system 0% cpu 10.072 total
```